### PR TITLE
Error in stylesheets images need to resolve with asset pipeline helper

### DIFF
--- a/vendor/assets/stylesheets/jquery.fileupload-ui.css.erb
+++ b/vendor/assets/stylesheets/jquery.fileupload-ui.css.erb
@@ -37,7 +37,7 @@
   width: 200px;
 }
 .progress-animated .bar {
-  background: image-url('images/progressbar.gif') !important;
+  background: url(<%= asset_path 'progressbar.gif' %>) !important;
   filter: none;
 }
 .fileupload-loading {
@@ -45,7 +45,7 @@
   left: 50%;
   width: 128px;
   height: 128px;
-  background: image-url('images/loading.gif') center no-repeat;
+  background: url(<%= asset_path 'images/loading.gif' %>) center no-repeat;
   display: none;
 }
 .fileupload-processing .fileupload-loading {


### PR DESCRIPTION
I was getting this error message and realized that images in the stylesheet weren't being referenced correctly.

``` ruby
Started GET "/img/loading.gif" for 127.0.0.1 at 2012-05-19 17:08:53 +0200
Processing by MainController#index as GIF
  Parameters: {"path"=>"img/loading"}
ActionView::MissingTemplate (Missing template main/index, application/index with {:locale=>[:en], :formats=>[:gif], :handlers=>[:erb, :builder, :coffee, :haml]}. Searched in:
  * "/Users/pschmitz/code/personal/portfolio/app/views"
  * "/Users/pschmitz/.rvm/gems/ruby-1.9.3-p0@portfolio/gems/twitter-bootstrap-rails-2.0.7/app/views"
...
):


```

I pointed the image ref to the right place using the image-url helper
