### PR TITLE
depend on sassc instead of deprecated sass gem [fixes #96]

### DIFF
--- a/jquery-fileupload-rails.gemspec
+++ b/jquery-fileupload-rails.gemspec
@@ -21,5 +21,5 @@ Gem::Specification.new do |s|
   s.add_dependency             'railties',   '>= 3.1'
   s.add_dependency             'actionpack', '>= 3.1'
   s.add_development_dependency 'rails', '>= 3.1'
-  s.add_runtime_dependency     'sass', '>= 3.2'
+  s.add_dependency             'sassc'
 end


### PR DESCRIPTION
The Sass gem is deprecated with the EOL in March. The sassc gem is a drop in replacement. See issue #96.